### PR TITLE
Add reference search

### DIFF
--- a/PyTrinamic/connections/tmcl_interface.py
+++ b/PyTrinamic/connections/tmcl_interface.py
@@ -245,6 +245,10 @@ class tmcl_interface():
         """
         return self.move(1, motor, distance, moduleID).value
 
+    def referenceSearch(self, commandType, motor, moduleID=None):
+        """Use the TMCL RFS command to search for the reference points."""
+        return self.send(TMCL_Command.RFS, commandType, motor, moduleID)
+
     # IO pin functions
     def analogInput(self, x, moduleID=None):
         return self.send(TMCL_Command.GIO, x, 1, 0, moduleID).value

--- a/PyTrinamic/connections/tmcl_interface.py
+++ b/PyTrinamic/connections/tmcl_interface.py
@@ -247,7 +247,7 @@ class tmcl_interface():
 
     def referenceSearch(self, commandType, motor, moduleID=None):
         """Use the TMCL RFS command to search for the reference points."""
-        return self.send(TMCL_Command.RFS, commandType, motor, moduleID)
+        return self.send(TMCL_Command.RFS, commandType, motor, 0, moduleID).value
 
     # IO pin functions
     def analogInput(self, x, moduleID=None):

--- a/PyTrinamic/modules/TMCM3110/TMCM_3110.py
+++ b/PyTrinamic/modules/TMCM3110/TMCM_3110.py
@@ -60,9 +60,14 @@ class TMCM_3110():
         return position
 
     def startReferenceSearch(self, motor, mode=None):
+        """Start the reference search for `motor` in `mode`."""
         if mode:
             self.setReferenceSearchMode(motor, mode)
-        self.connection.referenceSearch(1, motor)
+        self.connection.referenceSearch(0, motor)
+
+    def getReferenceSearchStatus(self, motor):
+        """Get the status, whether reference search is active."""
+        self.connection.referenceSearch(2, motor)
 
     # Current control functions
     def setMotorRunCurrent(self, motor, current):

--- a/PyTrinamic/modules/TMCM3110/TMCM_3110.py
+++ b/PyTrinamic/modules/TMCM3110/TMCM_3110.py
@@ -65,9 +65,12 @@ class TMCM_3110():
             self.setReferenceSearchMode(motor, mode)
         self.connection.referenceSearch(0, motor)
 
+    def stopReferenceSearch(self, motor):
+        self.connection.referenceSearch(1, motor)
+
     def getReferenceSearchStatus(self, motor):
         """Get the status, whether reference search is active."""
-        self.connection.referenceSearch(2, motor)
+        return self.connection.referenceSearch(2, motor)
 
     # Current control functions
     def setMotorRunCurrent(self, motor, current):

--- a/PyTrinamic/modules/TMCM3110/TMCM_3110.py
+++ b/PyTrinamic/modules/TMCM3110/TMCM_3110.py
@@ -59,6 +59,11 @@ class TMCM_3110():
 
         return position
 
+    def startReferenceSearch(self, motor, mode=None):
+        if mode:
+            self.setReferenceSearchMode(motor, mode)
+        self.connection.referenceSearch(1, motor)
+
     # Current control functions
     def setMotorRunCurrent(self, motor, current):
         self.setMaxCurrent(motor, current)
@@ -121,6 +126,15 @@ class TMCM_3110():
 
     def setRampMode(self, motor, mode):
         return self.setAxisParameter(self.APs.RampMode, motor, mode)
+
+    def setReferenceSearchMode(self, motor, mode):
+        return self.setAxisParameter(self.APs.ReferenceSearchMode, motor, mode)
+
+    def setReferenceSearchSpeed(self, motor, speed):
+        return self.setAxisParameter(self.APs.ReferenceSearchSpeed, motor, speed)
+
+    def setReferenceSwitchSpeed(self, motor, speed):
+        return self.setAxisParameter(self.APs.ReferenceSwitchSpeed, motor, speed)
 
     # Status functions
     def getStatusFlags(self, motor):


### PR DESCRIPTION
Adding the _reference search_ command to the tmcl_interface in order to let a motor search its reference point.
As an example implementation the TMCM3110 card allows setting the corresponding parameters, start the search and query its current status.

fixes #31 