### PR TITLE
Allow axis parameter to return signed values.

### DIFF
--- a/PyTrinamic/modules/TMCM3110/TMCM_3110.py
+++ b/PyTrinamic/modules/TMCM3110/TMCM_3110.py
@@ -7,8 +7,9 @@ Created on 05.06.2020
 class TMCM_3110():
     MOTORS = 3
 
-    def __init__(self, connection):
+    def __init__(self, connection, signed=False):
         self.connection = connection
+        self.signed = signed
 
         #self.GPs   = _GPs
         self.APs   = _APs
@@ -23,14 +24,14 @@ class TMCM_3110():
 
     # Axis parameter access
     def getAxisParameter(self, apType, motor):
-        return self.connection.axisParameter(apType, motor)
+        return self.connection.axisParameter(apType, motor, signed=self.signed)
 
     def setAxisParameter(self, apType, motor, value):
         self.connection.setAxisParameter(apType, motor, value)
 
     # Global parameter access
     def getGlobalParameter(self, gpType, bank):
-        return self.connection.globalParameter(gpType, bank)
+        return self.connection.globalParameter(gpType, bank, signed=self.signed)
 
     def setGlobalParameter(self, gpType, bank, value):
         self.connection.setGlobalParameter(gpType, bank, value)


### PR DESCRIPTION
Fixes #54 for TMCM_3110

An optional parameter of the module enables the conversion to signed ints of the axisParameter function in tmcl_connection.

I made the code for the TMCM_3110 module, it could be done for the other modules as well, if desired. I just tested it for this module.