### PR TITLE
tmcl_interface: Fix TMCL exception on receiving ascii firmware version

### DIFF
--- a/pytrinamic/connections/tmcl_interface.py
+++ b/pytrinamic/connections/tmcl_interface.py
@@ -117,7 +117,9 @@ class TmclInterface(ABC):
 
         self._reply_check(reply)
 
-        if reply.status < 100:  # status codes below 100 indicate an error response
+        # Status codes below 100 indicate an error response.
+        # Ignore status when receiving the ascii firmware version.
+        if reply.status < 100 and request.command != TMCLCommand.GET_FIRMWARE_VERSION:
             raise TMCLReplyStatusError(reply)
 
         return reply


### PR DESCRIPTION
Ascii firmware version reply (command 136) doesn't follow standard TMCL reply format. All bytes are used to transmit ascii characters, which can trigger a status error exception wrongly. This special case should be addressed here, in case thi request is made, we never throw status exceptions.