### PR TITLE
Relative imports instead of absolute imports

### DIFF
--- a/pytrinamic/connections/connection_manager.py
+++ b/pytrinamic/connections/connection_manager.py
@@ -1,15 +1,15 @@
 import sys
 import argparse
 
-from pytrinamic.connections import DummyTmclInterface
-from pytrinamic.connections import PcanTmclInterface
-from pytrinamic.connections import SocketcanTmclInterface
-from pytrinamic.connections import KvaserTmclInterface
-from pytrinamic.connections import SerialTmclInterface
-from pytrinamic.connections import UartIcInterface
-from pytrinamic.connections import UsbTmclInterface
-from pytrinamic.connections import SlcanTmclInterface
-from pytrinamic.connections import IxxatTmclInterface
+from ..connections import DummyTmclInterface
+from ..connections import PcanTmclInterface
+from ..connections import SocketcanTmclInterface
+from ..connections import KvaserTmclInterface
+from ..connections import SerialTmclInterface
+from ..connections import UartIcInterface
+from ..connections import UsbTmclInterface
+from ..connections import SlcanTmclInterface
+from ..connections import IxxatTmclInterface
 
 
 class ConnectionManager:

--- a/pytrinamic/connections/dummy_tmcl_interface.py
+++ b/pytrinamic/connections/dummy_tmcl_interface.py
@@ -1,4 +1,4 @@
-from pytrinamic.connections.tmcl_interface import TmclInterface
+from ..connections.tmcl_interface import TmclInterface
 
 
 class DummyTmclInterface(TmclInterface):

--- a/pytrinamic/connections/ixxat_tmcl_interface.py
+++ b/pytrinamic/connections/ixxat_tmcl_interface.py
@@ -1,6 +1,6 @@
 import can
 from can import CanError
-from pytrinamic.connections.tmcl_interface import TmclInterface
+from ..connections.tmcl_interface import TmclInterface
 
 # Providing 5 channels here, this should cover all use cases.
 # Ixxat USB-to-CAN provides 1, 2 or 4 channels.

--- a/pytrinamic/connections/kvaser_tmcl_interface.py
+++ b/pytrinamic/connections/kvaser_tmcl_interface.py
@@ -1,6 +1,6 @@
 import can
 from can import CanError
-from pytrinamic.connections.tmcl_interface import TmclInterface
+from ..connections.tmcl_interface import TmclInterface
 
 _CHANNELS = ["0",  "1",  "2"]
 

--- a/pytrinamic/connections/pcan_tmcl_interface.py
+++ b/pytrinamic/connections/pcan_tmcl_interface.py
@@ -2,7 +2,7 @@
 import can
 from can import CanError
 from can.interfaces.pcan.pcan import PcanError
-from pytrinamic.connections.tmcl_interface import TmclInterface
+from ..connections.tmcl_interface import TmclInterface
 
 _CHANNELS = [
     "PCAN_USBBUS1",  "PCAN_USBBUS2",  "PCAN_USBBUS3",  "PCAN_USBBUS4",

--- a/pytrinamic/connections/serial_tmcl_interface.py
+++ b/pytrinamic/connections/serial_tmcl_interface.py
@@ -1,7 +1,7 @@
 from serial import Serial, SerialException
 import serial.tools.list_ports
-from pytrinamic.connections.tmcl_interface import TmclInterface
-from pytrinamic.tmcl import TMCLReplyChecksumError
+from ..connections.tmcl_interface import TmclInterface
+from ..tmcl import TMCLReplyChecksumError
 
 
 class SerialTmclInterface(TmclInterface):

--- a/pytrinamic/connections/slcan_tmcl_interface.py
+++ b/pytrinamic/connections/slcan_tmcl_interface.py
@@ -1,7 +1,7 @@
 import can
 from can import CanError
 from serial.tools.list_ports import comports
-from pytrinamic.connections.tmcl_interface import TmclInterface
+from ..connections.tmcl_interface import TmclInterface
 
 
 class SlcanTmclInterface(TmclInterface):

--- a/pytrinamic/connections/socketcan_tmcl_interface.py
+++ b/pytrinamic/connections/socketcan_tmcl_interface.py
@@ -1,6 +1,6 @@
 import can
 from can import CanError
-from pytrinamic.connections.tmcl_interface import TmclInterface
+from ..connections.tmcl_interface import TmclInterface
 
 _CHANNELS = ["can0",  "can1",  "can2",  "can3",  "can4",  "can5",  "can6",  "can7"]
 

--- a/pytrinamic/connections/tmcl_interface.py
+++ b/pytrinamic/connections/tmcl_interface.py
@@ -1,6 +1,6 @@
 from abc import ABC
-from pytrinamic.tmcl import TMCL, TMCLRequest, TMCLCommand, TMCLReply, TMCLReplyChecksumError, TMCLReplyStatusError
-from pytrinamic.helpers import TMC_helpers
+from ..tmcl import TMCL, TMCLRequest, TMCLCommand, TMCLReply, TMCLReplyChecksumError, TMCLReplyStatusError
+from ..helpers import TMC_helpers
 
 
 class TmclInterface(ABC):

--- a/pytrinamic/connections/usb_tmcl_interface.py
+++ b/pytrinamic/connections/usb_tmcl_interface.py
@@ -1,5 +1,5 @@
 import serial.tools.list_ports
-from pytrinamic.connections.serial_tmcl_interface import SerialTmclInterface
+from ..connections.serial_tmcl_interface import SerialTmclInterface
 
 
 class UsbTmclInterface(SerialTmclInterface):

--- a/pytrinamic/features/abn_encoder_module.py
+++ b/pytrinamic/features/abn_encoder_module.py
@@ -1,4 +1,4 @@
-from pytrinamic.features.abn_encoder import ABNEncoder
+from ..features.abn_encoder import ABNEncoder
 
 
 class ABNEncoderModule(ABNEncoder):

--- a/pytrinamic/features/absolute_encoder_module.py
+++ b/pytrinamic/features/absolute_encoder_module.py
@@ -1,4 +1,4 @@
-from pytrinamic.features.absolute_encoder import AbsoluteEncoder
+from ..features.absolute_encoder import AbsoluteEncoder
 
 
 class AbsoluteEncoderModule(AbsoluteEncoder):

--- a/pytrinamic/features/coolstep_module.py
+++ b/pytrinamic/features/coolstep_module.py
@@ -1,4 +1,4 @@
-from pytrinamic.features.coolstep import CoolStep
+from ..features.coolstep import CoolStep
 import time
 
 

--- a/pytrinamic/features/digital_hall_module.py
+++ b/pytrinamic/features/digital_hall_module.py
@@ -1,4 +1,4 @@
-from pytrinamic.features.digital_hall import DigitalHall
+from ..features.digital_hall import DigitalHall
 
 
 class DigitalHallModule(DigitalHall):

--- a/pytrinamic/features/drive_setting_module.py
+++ b/pytrinamic/features/drive_setting_module.py
@@ -1,4 +1,4 @@
-from pytrinamic.features.drive_setting import DriveSetting
+from ..features.drive_setting import DriveSetting
 
 
 class DriveSettingModule(DriveSetting):

--- a/pytrinamic/features/linear_ramp_module.py
+++ b/pytrinamic/features/linear_ramp_module.py
@@ -1,4 +1,4 @@
-from pytrinamic.features.linear_ramp import LinearRamp
+from ..features.linear_ramp import LinearRamp
 
 
 class LinearRampModule(LinearRamp):

--- a/pytrinamic/features/motor_control_ic.py
+++ b/pytrinamic/features/motor_control_ic.py
@@ -1,5 +1,5 @@
-from pytrinamic.features.motor_control import MotorControl
-from pytrinamic.helpers import TMC_helpers
+from ..features.motor_control import MotorControl
+from ..helpers import TMC_helpers
 
 
 class MotorControlIc(MotorControl):

--- a/pytrinamic/features/motor_control_module.py
+++ b/pytrinamic/features/motor_control_module.py
@@ -1,4 +1,4 @@
-from pytrinamic.features.motor_control import MotorControl
+from ..features.motor_control import MotorControl
 
 
 class MotorControlModule(MotorControl):

--- a/pytrinamic/features/pid_module.py
+++ b/pytrinamic/features/pid_module.py
@@ -1,4 +1,4 @@
-from pytrinamic.features.pid import PID
+from ..features.pid import PID
 
 
 class PIDModule(PID):

--- a/pytrinamic/features/stallguard2_module.py
+++ b/pytrinamic/features/stallguard2_module.py
@@ -1,4 +1,4 @@
-from pytrinamic.features.stallguard2 import StallGuard2
+from ..features.stallguard2 import StallGuard2
 import time
 
 

--- a/pytrinamic/helpers.py
+++ b/pytrinamic/helpers.py
@@ -1,4 +1,4 @@
-from pytrinamic import name, desc
+from . import name, desc
 
 
 class TMC_helpers(object):

--- a/pytrinamic/ic/MAX22216.py
+++ b/pytrinamic/ic/MAX22216.py
@@ -1,4 +1,5 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
+
 
 class MAX22216(TMCIc):
     """

--- a/pytrinamic/ic/TMC2100.py
+++ b/pytrinamic/ic/TMC2100.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC2100(TMCIc):

--- a/pytrinamic/ic/TMC2130.py
+++ b/pytrinamic/ic/TMC2130.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC2130(TMCIc):

--- a/pytrinamic/ic/TMC2160.py
+++ b/pytrinamic/ic/TMC2160.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC2160(TMCIc):

--- a/pytrinamic/ic/TMC2208.py
+++ b/pytrinamic/ic/TMC2208.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC2208(TMCIc):

--- a/pytrinamic/ic/TMC2209.py
+++ b/pytrinamic/ic/TMC2209.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC2209(TMCIc):

--- a/pytrinamic/ic/TMC2224.py
+++ b/pytrinamic/ic/TMC2224.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC2224(TMCIc):

--- a/pytrinamic/ic/TMC2225.py
+++ b/pytrinamic/ic/TMC2225.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC2225(TMCIc):

--- a/pytrinamic/ic/TMC2300.py
+++ b/pytrinamic/ic/TMC2300.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC2300(TMCIc):

--- a/pytrinamic/ic/TMC2590.py
+++ b/pytrinamic/ic/TMC2590.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC2590(TMCIc):

--- a/pytrinamic/ic/TMC2660.py
+++ b/pytrinamic/ic/TMC2660.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC2660(TMCIc):

--- a/pytrinamic/ic/TMC4361.py
+++ b/pytrinamic/ic/TMC4361.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC4361(TMCIc):

--- a/pytrinamic/ic/TMC4671.py
+++ b/pytrinamic/ic/TMC4671.py
@@ -1,6 +1,6 @@
 import struct
-from pytrinamic.ic.tmc_ic import TMCIc
-from pytrinamic.helpers import TMC_helpers
+from ..ic.tmc_ic import TMCIc
+from ..helpers import TMC_helpers
 
 DATAGRAM_FORMAT = ">BI"
 DATAGRAM_LENGTH = 5

--- a/pytrinamic/ic/TMC5031.py
+++ b/pytrinamic/ic/TMC5031.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC5031(TMCIc):

--- a/pytrinamic/ic/TMC5041.py
+++ b/pytrinamic/ic/TMC5041.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC5041(TMCIc):

--- a/pytrinamic/ic/TMC5062.py
+++ b/pytrinamic/ic/TMC5062.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC5062(TMCIc):

--- a/pytrinamic/ic/TMC5072.py
+++ b/pytrinamic/ic/TMC5072.py
@@ -1,7 +1,7 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 # features
-from pytrinamic.features.motor_control_ic import MotorControlIc
+from ..features.motor_control_ic import MotorControlIc
 # from pytrinamic.features.LinearRampIC import LinearRampIC
 # from pytrinamic.features.CurrentIC import CurrentIC
 # from pytrinamic.features.StallGuard2IC import StallGuard2IC

--- a/pytrinamic/ic/TMC5130.py
+++ b/pytrinamic/ic/TMC5130.py
@@ -1,7 +1,7 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 # features
-from pytrinamic.features.motor_control_ic import MotorControlIc
+from ..features.motor_control_ic import MotorControlIc
 # from pytrinamic.features.linear_ramp_ic import LinearRampIC
 # from pytrinamic.features.current_ic import CurrentIC
 # from pytrinamic.features.stallguard2_ic import StallGuard2IC

--- a/pytrinamic/ic/TMC5160.py
+++ b/pytrinamic/ic/TMC5160.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC5160(TMCIc):

--- a/pytrinamic/ic/TMC6100.py
+++ b/pytrinamic/ic/TMC6100.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC6100(TMCIc):

--- a/pytrinamic/ic/TMC6200.py
+++ b/pytrinamic/ic/TMC6200.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC6200(TMCIc):

--- a/pytrinamic/ic/TMC6300.py
+++ b/pytrinamic/ic/TMC6300.py
@@ -1,4 +1,4 @@
-from pytrinamic.ic.tmc_ic import TMCIc
+from ..ic.tmc_ic import TMCIc
 
 
 class TMC6300(TMCIc):

--- a/pytrinamic/ic/TMC7300.py
+++ b/pytrinamic/ic/TMC7300.py
@@ -1,6 +1,6 @@
 import struct
-from pytrinamic.ic.tmc_ic import TMCIc
-from pytrinamic.helpers import TMC_helpers
+from ..ic.tmc_ic import TMCIc
+from ..helpers import TMC_helpers
 
 DATAGRAM_FORMAT = ">BI"
 DATAGRAM_LENGTH = 5

--- a/pytrinamic/modules/TMCC160.py
+++ b/pytrinamic/modules/TMCC160.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import ABNEncoderModule, DigitalHallModule, PIDModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import ABNEncoderModule, DigitalHallModule, PIDModule
 
 
 class TMCC160(TMCLModule):

--- a/pytrinamic/modules/TMCM1140.py
+++ b/pytrinamic/modules/TMCM1140.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import StallGuard2Module, CoolStepModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import StallGuard2Module, CoolStepModule
 
 
 class TMCM1140(TMCLModule):

--- a/pytrinamic/modules/TMCM1141.py
+++ b/pytrinamic/modules/TMCM1141.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import StallGuard2Module, CoolStepModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import StallGuard2Module, CoolStepModule
 
 
 class TMCM1141(TMCLModule):

--- a/pytrinamic/modules/TMCM1160.py
+++ b/pytrinamic/modules/TMCM1160.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import StallGuard2Module, CoolStepModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import StallGuard2Module, CoolStepModule
 
 
 class TMCM1160(TMCLModule):

--- a/pytrinamic/modules/TMCM1161.py
+++ b/pytrinamic/modules/TMCM1161.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import StallGuard2Module, CoolStepModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import StallGuard2Module, CoolStepModule
 
 
 class TMCM1161(TMCLModule):

--- a/pytrinamic/modules/TMCM1240.py
+++ b/pytrinamic/modules/TMCM1240.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import StallGuard2Module, CoolStepModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import StallGuard2Module, CoolStepModule
 
 
 class TMCM1240(TMCLModule):

--- a/pytrinamic/modules/TMCM1260.py
+++ b/pytrinamic/modules/TMCM1260.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import StallGuard2Module, CoolStepModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import StallGuard2Module, CoolStepModule
 
 
 class TMCM1260(TMCLModule):

--- a/pytrinamic/modules/TMCM1270.py
+++ b/pytrinamic/modules/TMCM1270.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import StallGuard2Module, CoolStepModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import StallGuard2Module, CoolStepModule
 
 
 class TMCM1270(TMCLModule):

--- a/pytrinamic/modules/TMCM1276.py
+++ b/pytrinamic/modules/TMCM1276.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import StallGuard2Module, CoolStepModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import StallGuard2Module, CoolStepModule
 
 
 class TMCM1276(TMCLModule):

--- a/pytrinamic/modules/TMCM1370.py
+++ b/pytrinamic/modules/TMCM1370.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import StallGuard2Module, CoolStepModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import StallGuard2Module, CoolStepModule
 
 
 class TMCM1370(TMCLModule):

--- a/pytrinamic/modules/TMCM1617.py
+++ b/pytrinamic/modules/TMCM1617.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
-from pytrinamic.ic import TMC4671, TMC6200
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import ABNEncoderModule, DigitalHallModule, PIDModule
-from pytrinamic.helpers import TMC_helpers
+from ..modules import TMCLModule
+from ..ic import TMC4671, TMC6200
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import ABNEncoderModule, DigitalHallModule, PIDModule
+from ..helpers import TMC_helpers
 
 
 class TMCM1617(TMCLModule):

--- a/pytrinamic/modules/TMCM1630.py
+++ b/pytrinamic/modules/TMCM1630.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import ABNEncoderModule, DigitalHallModule, PIDModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import ABNEncoderModule, DigitalHallModule, PIDModule
 
 
 class TMCM1630(TMCLModule):

--- a/pytrinamic/modules/TMCM1633.py
+++ b/pytrinamic/modules/TMCM1633.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import ABNEncoderModule, DigitalHallModule, PIDModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import ABNEncoderModule, DigitalHallModule, PIDModule
 
 
 class TMCM1633(TMCLModule):

--- a/pytrinamic/modules/TMCM1636.py
+++ b/pytrinamic/modules/TMCM1636.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule, ABNEncoderModule
-from pytrinamic.features import DigitalHallModule, PIDModule, AbsoluteEncoderModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule, ABNEncoderModule
+from ..features import DigitalHallModule, PIDModule, AbsoluteEncoderModule
 
 
 class TMCM1636(TMCLModule):

--- a/pytrinamic/modules/TMCM1637.py
+++ b/pytrinamic/modules/TMCM1637.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule, ABNEncoderModule
-from pytrinamic.features import DigitalHallModule, PIDModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule, ABNEncoderModule
+from ..features import DigitalHallModule, PIDModule
 
 
 class TMCM1637(TMCLModule):

--- a/pytrinamic/modules/TMCM1638.py
+++ b/pytrinamic/modules/TMCM1638.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule, ABNEncoderModule
-from pytrinamic.features import DigitalHallModule, PIDModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule, ABNEncoderModule
+from ..features import DigitalHallModule, PIDModule
 
 
 class TMCM1638(TMCLModule):

--- a/pytrinamic/modules/TMCM1640.py
+++ b/pytrinamic/modules/TMCM1640.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import ABNEncoderModule, DigitalHallModule, PIDModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import ABNEncoderModule, DigitalHallModule, PIDModule
 
 
 class TMCM1640(TMCLModule):

--- a/pytrinamic/modules/TMCM1670.py
+++ b/pytrinamic/modules/TMCM1670.py
@@ -1,6 +1,6 @@
-from pytrinamic.modules import TMCLModule
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule, AbsoluteEncoderModule
-from pytrinamic.features import PIDModule
+from ..modules import TMCLModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule, AbsoluteEncoderModule
+from ..features import PIDModule
 
 
 class TMCM1670(TMCLModule):

--- a/pytrinamic/modules/TMCM3110.py
+++ b/pytrinamic/modules/TMCM3110.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import StallGuard2Module, CoolStepModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import StallGuard2Module, CoolStepModule
 
 
 class TMCM3110(TMCLModule):

--- a/pytrinamic/modules/TMCM3312.py
+++ b/pytrinamic/modules/TMCM3312.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import StallGuard2Module, CoolStepModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import StallGuard2Module, CoolStepModule
 
 
 class TMCM3312(TMCLModule):

--- a/pytrinamic/modules/TMCM3351.py
+++ b/pytrinamic/modules/TMCM3351.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import StallGuard2Module, CoolStepModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import StallGuard2Module, CoolStepModule
 
 
 class TMCM3351(TMCLModule):

--- a/pytrinamic/modules/TMCM6110.py
+++ b/pytrinamic/modules/TMCM6110.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import StallGuard2Module, CoolStepModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import StallGuard2Module, CoolStepModule
 
 
 class TMCM6110(TMCLModule):

--- a/pytrinamic/modules/TMCM6212.py
+++ b/pytrinamic/modules/TMCM6212.py
@@ -1,8 +1,8 @@
-from pytrinamic.modules import TMCLModule
+from ..modules import TMCLModule
 
 # features
-from pytrinamic.features import MotorControlModule, DriveSettingModule, LinearRampModule
-from pytrinamic.features import StallGuard2Module, CoolStepModule
+from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
+from ..features import StallGuard2Module, CoolStepModule
 
 
 class TMCM6212(TMCLModule):

--- a/pytrinamic/modules/__init__.py
+++ b/pytrinamic/modules/__init__.py
@@ -1,6 +1,7 @@
 from .tmcl_module import TMCLModule
 from .TMCC160 import TMCC160
 from .TMCM1140 import TMCM1140
+from .TMCM1141 import TMCM1141
 from .TMCM1160 import TMCM1160
 from .TMCM1161 import TMCM1161
 from .TMCM1240 import TMCM1240


### PR DESCRIPTION
- Add module TMCM1141 to modules __init.py__

Signed-off-by: zomberg <mario.berger@zeiss.com>