### PR TITLE
Add: optional rx timeout arguments for the interfaces

### DIFF
--- a/pytrinamic/connections/connection_manager.py
+++ b/pytrinamic/connections/connection_manager.py
@@ -312,17 +312,15 @@ class ConnectionManager:
         script, this function adds the arguments of the ConnectionManager to the
         argparse parser.
         """
-        class GreaterThanZeroFloat:
-            """Checker for float choice.
-
-            assert 1.0 == GreaterThanZeroFloat()
-            assert 0.0 != GreaterThanZeroFloat()
+        def _positive_float(value):
             """
-            def __eq__(self, other):
-                return other > 0.0
+            Argparse checker for float a positive float type.
+            """
+            value_float = float(value)
+            if value_float < 0:
+                raise argparse.ArgumentTypeError("Expected a positive float, got {}".format(value_float))
 
-            def __repr__(self):
-                return "x > 0.0"
+            return value_float
 
         group = arg_parser.add_argument_group("ConnectionManager options")
         group.add_argument('--interface', dest='interface', action='store', nargs=1, type=str,
@@ -334,8 +332,8 @@ class ConnectionManager:
                            help='Exclude ports')
         group.add_argument('--data-rate', dest='data_rate', action='store', nargs=1, type=int,
                            help='Connection data-rate (default: %(default)s)')
-        group.add_argument('--timeout', dest='timeout_s', action='store', nargs=1, type=float, default=[5.0], choices=[GreaterThanZeroFloat()],
-                           help='Connection rx timeout in seconds(default: %(default)s)', metavar='<float_greater_than_zero>')
+        group.add_argument('--timeout', dest='timeout_s', action='store', nargs=1, type=_positive_float, default=5.0,
+                           help='Connection rx timeout in seconds (default: %(default)s)', metavar="SECONDS")
 
         group = arg_parser.add_argument_group("ConnectionManager TMCL options")
 

--- a/pytrinamic/connections/connection_manager.py
+++ b/pytrinamic/connections/connection_manager.py
@@ -162,7 +162,7 @@ class ConnectionManager:
             pass
 
         # Timeout
-        self.__timeout_s = args.timeout_s[0]
+        self.__timeout_s = args.timeout_s
 
         # Host ID
         try:
@@ -332,7 +332,7 @@ class ConnectionManager:
                            help='Exclude ports')
         group.add_argument('--data-rate', dest='data_rate', action='store', nargs=1, type=int,
                            help='Connection data-rate (default: %(default)s)')
-        group.add_argument('--timeout', dest='timeout_s', action='store', nargs=1, type=_positive_float, default=5.0,
+        group.add_argument('--timeout', dest='timeout_s', action='store', type=_positive_float, default=5.0,
                            help='Connection rx timeout in seconds (default: %(default)s)', metavar="SECONDS")
 
         group = arg_parser.add_argument_group("ConnectionManager TMCL options")

--- a/pytrinamic/connections/connection_manager.py
+++ b/pytrinamic/connections/connection_manager.py
@@ -63,10 +63,15 @@ class ConnectionManager:
             interpreted depends on the interface used. E.g. the serial
             connection uses this value as the baud rate.
 
-            Default value: 115200
+            The Default value also depends on the interface.
+                * for any CAN interface its 1000000
+                * for the serial_tmcl and uard_id interface it is 9600
+                * for usb_tmcl it is 115200
 
         --timeout <timeout in s>
-            The rx timeout. The value should be larger than 0.
+            The rx timeout in seconds. Accepts only values >= 0.
+            If 0 is given the rx function will block forever.
+            This might be useful for debugging.
 
             Default value: 5.0
 

--- a/pytrinamic/connections/dummy_tmcl_interface.py
+++ b/pytrinamic/connections/dummy_tmcl_interface.py
@@ -3,7 +3,7 @@ from pytrinamic.connections.tmcl_interface import TmclInterface
 
 class DummyTmclInterface(TmclInterface):
 
-    def __init__(self, port, datarate=115200, host_id=2, module_id=1, debug=True):
+    def __init__(self, port, datarate=115200, host_id=2, module_id=1, debug=True, timeout_s=5):
         """
         Opens a dummy TMCL connection
         """
@@ -17,6 +17,7 @@ class DummyTmclInterface(TmclInterface):
             print("\tData rate:  " + str(datarate))
             print("\tHost ID:    " + str(host_id))
             print("\tModule ID:  " + str(module_id))
+            print("\tTimeout:    " + str(timeout_s))
 
     def __enter__(self):
         return self

--- a/pytrinamic/connections/ixxat_tmcl_interface.py
+++ b/pytrinamic/connections/ixxat_tmcl_interface.py
@@ -27,7 +27,7 @@ class IxxatTmclInterface(TmclInterface):
             print("Found IXXAT adapter with hardware id '%s'." % hwid)
     """
 
-    def __init__(self, port="0", datarate=1000000, host_id=2, module_id=1, debug=False):
+    def __init__(self, port="0", datarate=1000000, host_id=2, module_id=1, debug=False, timeout_s=5):
         if not isinstance(port, str):
             raise TypeError
 
@@ -37,6 +37,7 @@ class IxxatTmclInterface(TmclInterface):
         TmclInterface.__init__(self, host_id, module_id, debug)
         self._channel = port
         self._bitrate = datarate
+        self._timeout_s = timeout_s
 
         try:
             if self._debug:
@@ -100,7 +101,7 @@ class IxxatTmclInterface(TmclInterface):
         del module_id
 
         try:
-            msg = self._connection.recv(timeout=3)
+            msg = self._connection.recv(timeout=self._timeout_s)
         except CanError as e:
             raise ConnectionError(
                 f"Failed to receive a TMCL message from {self.__class__.__name__} (channel {str(self._channel)})"

--- a/pytrinamic/connections/ixxat_tmcl_interface.py
+++ b/pytrinamic/connections/ixxat_tmcl_interface.py
@@ -37,7 +37,10 @@ class IxxatTmclInterface(TmclInterface):
         TmclInterface.__init__(self, host_id, module_id, debug)
         self._channel = port
         self._bitrate = datarate
-        self._timeout_s = timeout_s
+        if timeout_s == 0:
+            self._timeout_s = None
+        else:
+            self._timeout_s = timeout_s
 
         try:
             if self._debug:

--- a/pytrinamic/connections/kvaser_tmcl_interface.py
+++ b/pytrinamic/connections/kvaser_tmcl_interface.py
@@ -20,7 +20,10 @@ class KvaserTmclInterface(TmclInterface):
         TmclInterface.__init__(self, host_id, module_id, debug)
         self._channel = port
         self._bitrate = datarate
-        self._timeout_s = timeout_s
+        if timeout_s == 0:
+            self._timeout_s = None
+        else:
+            self._timeout_s = timeout_s
 
         try:
             if self._debug:

--- a/pytrinamic/connections/kvaser_tmcl_interface.py
+++ b/pytrinamic/connections/kvaser_tmcl_interface.py
@@ -10,7 +10,7 @@ class KvaserTmclInterface(TmclInterface):
     This class implements a TMCL connection for Kvaser adapter using CANLIB.
     Try 0 as default channel.
     """
-    def __init__(self, port="0", datarate=1000000, host_id=2, module_id=1, debug=False):
+    def __init__(self, port="0", datarate=1000000, host_id=2, module_id=1, debug=False, timeout_s=5):
         if not isinstance(port, str):
             raise TypeError
 
@@ -20,6 +20,7 @@ class KvaserTmclInterface(TmclInterface):
         TmclInterface.__init__(self, host_id, module_id, debug)
         self._channel = port
         self._bitrate = datarate
+        self._timeout_s = timeout_s
 
         try:
             if self._debug:
@@ -75,7 +76,7 @@ class KvaserTmclInterface(TmclInterface):
         del module_id
 
         try:
-            msg = self._connection.recv(timeout=3)
+            msg = self._connection.recv(timeout=self._timeout_s)
         except CanError as e:
             raise ConnectionError("Failed to receive a TMCL message") from e
 

--- a/pytrinamic/connections/pcan_tmcl_interface.py
+++ b/pytrinamic/connections/pcan_tmcl_interface.py
@@ -33,7 +33,7 @@ class PcanTmclInterface(TmclInterface):
     """
     This class implements a TMCL connection over a PCAN adapter.
     """
-    def __init__(self, port, datarate=1000000, host_id=2, module_id=1, debug=False):
+    def __init__(self, port, datarate=1000000, host_id=2, module_id=1, debug=False, timeout_s=5):
         if not isinstance(port, str):
             raise TypeError
 
@@ -43,6 +43,7 @@ class PcanTmclInterface(TmclInterface):
         TmclInterface.__init__(self, host_id, module_id, debug)
         self._channel = port
         self._bitrate = datarate
+        self._timeout_s = timeout_s
 
         try:
             self._connection = can.Bus(interface="pcan", channel=self._channel, bitrate=self._bitrate)
@@ -95,7 +96,7 @@ class PcanTmclInterface(TmclInterface):
         del module_id
 
         try:
-            msg = self._connection.recv(timeout=3)
+            msg = self._connection.recv(timeout=self._timeout_s)
         except CanError as e:
             raise ConnectionError("Failed to receive a TMCL message") from e
 

--- a/pytrinamic/connections/pcan_tmcl_interface.py
+++ b/pytrinamic/connections/pcan_tmcl_interface.py
@@ -43,7 +43,10 @@ class PcanTmclInterface(TmclInterface):
         TmclInterface.__init__(self, host_id, module_id, debug)
         self._channel = port
         self._bitrate = datarate
-        self._timeout_s = timeout_s
+        if timeout_s == 0:
+            self._timeout_s = None
+        else:
+            self._timeout_s = timeout_s
 
         try:
             self._connection = can.Bus(interface="pcan", channel=self._channel, bitrate=self._bitrate)

--- a/pytrinamic/connections/serial_tmcl_interface.py
+++ b/pytrinamic/connections/serial_tmcl_interface.py
@@ -14,6 +14,8 @@ class SerialTmclInterface(TmclInterface):
 
         TmclInterface.__init__(self, host_id, module_id, debug)
         self._baudrate = datarate
+        if timeout_s == 0:
+            timeout_s = None
 
         try:
             self._serial = Serial(com_port, self._baudrate, timeout=timeout_s)

--- a/pytrinamic/connections/serial_tmcl_interface.py
+++ b/pytrinamic/connections/serial_tmcl_interface.py
@@ -8,7 +8,7 @@ class SerialTmclInterface(TmclInterface):
     """
     Opens a serial TMCL connection
     """
-    def __init__(self, com_port, datarate=115200, host_id=2, module_id=1, debug=False):
+    def __init__(self, com_port, datarate=115200, host_id=2, module_id=1, debug=False, timeout_s=5):
         if not isinstance(com_port, str):
             raise TypeError
 
@@ -16,11 +16,9 @@ class SerialTmclInterface(TmclInterface):
         self._baudrate = datarate
 
         try:
-            self._serial = Serial(com_port, self._baudrate)
+            self._serial = Serial(com_port, self._baudrate, timeout=timeout_s)
         except SerialException as e:
             raise ConnectionError from e
-
-        self._serial.timeout = 5
 
         if self._debug:
             print("Opened port: " + self._serial.portstr)

--- a/pytrinamic/connections/slcan_tmcl_interface.py
+++ b/pytrinamic/connections/slcan_tmcl_interface.py
@@ -19,7 +19,10 @@ class SlcanTmclInterface(TmclInterface):
         TmclInterface.__init__(self, host_id, module_id, debug)
         self._bitrate = datarate
         self._port = com_port
-        self._timeout_s = timeout_s
+        if timeout_s == 0:
+            self._timeout_s = None
+        else:
+            self._timeout_s = timeout_s
         self._serial_baudrate = serial_baudrate
 
         try:

--- a/pytrinamic/connections/slcan_tmcl_interface.py
+++ b/pytrinamic/connections/slcan_tmcl_interface.py
@@ -12,13 +12,14 @@ class SlcanTmclInterface(TmclInterface):
     Maybe SerialBaudrate has to be changed based on adapter.
     """
 
-    def __init__(self, com_port, datarate=1000000, host_id=2, module_id=1, debug=True, serial_baudrate=115200):
+    def __init__(self, com_port, datarate=1000000, host_id=2, module_id=1, debug=True, timeout_s=5, serial_baudrate=115200):
         if not isinstance(com_port, str):
             raise TypeError
 
         TmclInterface.__init__(self, host_id, module_id, debug)
         self._bitrate = datarate
         self._port = com_port
+        self._timeout_s = timeout_s
         self._serial_baudrate = serial_baudrate
 
         try:
@@ -74,7 +75,7 @@ class SlcanTmclInterface(TmclInterface):
         del module_id
 
         try:
-            msg = self._connection.recv(timeout=3)
+            msg = self._connection.recv(timeout=self._timeout_s)
         except CanError as e:
             raise ConnectionError("Failed to receive a TMCL message") from e
 

--- a/pytrinamic/connections/socketcan_tmcl_interface.py
+++ b/pytrinamic/connections/socketcan_tmcl_interface.py
@@ -12,7 +12,7 @@ class SocketcanTmclInterface(TmclInterface):
     Use following command under linux to activate can socket
     sudo ip link set can0 down type can bitrate 1000000
     """
-    def __init__(self, port, datarate=1000000, host_id=2, module_id=1, debug=False):
+    def __init__(self, port, datarate=1000000, host_id=2, module_id=1, debug=False, timeout_s=5):
         if not isinstance(port, str):
             raise TypeError
 
@@ -22,6 +22,7 @@ class SocketcanTmclInterface(TmclInterface):
         TmclInterface.__init__(self, host_id, module_id, debug)
         self._channel = port
         self._bitrate = datarate
+        self._timeout_s = timeout_s
 
         try:
             self._connection = can.Bus(interface="socketcan", channel=self._channel, bitrate=self._bitrate)
@@ -76,7 +77,7 @@ class SocketcanTmclInterface(TmclInterface):
         del module_id
 
         try:
-            msg = self._connection.recv(timeout=3)
+            msg = self._connection.recv(timeout=self._timeout_s)
         except CanError as e:
             raise ConnectionError("Failed to receive a TMCL message") from e
 

--- a/pytrinamic/connections/socketcan_tmcl_interface.py
+++ b/pytrinamic/connections/socketcan_tmcl_interface.py
@@ -22,7 +22,10 @@ class SocketcanTmclInterface(TmclInterface):
         TmclInterface.__init__(self, host_id, module_id, debug)
         self._channel = port
         self._bitrate = datarate
-        self._timeout_s = timeout_s
+        if timeout_s == 0:
+            self._timeout_s = None
+        else:
+            self._timeout_s = timeout_s
 
         try:
             self._connection = can.Bus(interface="socketcan", channel=self._channel, bitrate=self._bitrate)

--- a/pytrinamic/connections/uart_ic_interface.py
+++ b/pytrinamic/connections/uart_ic_interface.py
@@ -32,10 +32,10 @@ class RegisterReply:
 
 class UartIcInterface:
 
-    def __init__(self, com_port, datarate=9600, debug=False):
+    def __init__(self, com_port, datarate=9600, debug=False, timeout_s=5):
         self._debug = debug
         self.baudrate = datarate
-        self.serial = Serial(com_port, self.baudrate)
+        self.serial = Serial(com_port, self.baudrate, timeout=timeout_s)
         print("Open port: " + self.serial.portstr)
 
     def __enter__(self):

--- a/pytrinamic/connections/uart_ic_interface.py
+++ b/pytrinamic/connections/uart_ic_interface.py
@@ -35,6 +35,8 @@ class UartIcInterface:
     def __init__(self, com_port, datarate=9600, debug=False, timeout_s=5):
         self._debug = debug
         self.baudrate = datarate
+        if timeout_s == 0:
+            timeout_s = None
         self.serial = Serial(com_port, self.baudrate, timeout=timeout_s)
         print("Open port: " + self.serial.portstr)
 

--- a/tests/test_interface_timeouts.py
+++ b/tests/test_interface_timeouts.py
@@ -1,0 +1,70 @@
+"""Test for the ConnectionManager timeout parameter.
+
+A (virtual) comport and a Kvaser CAN-Adapter are needed to run these tests.
+Note, you may need change the comport number.
+"""
+
+import time
+
+import pytest
+
+from pytrinamic.connections import ConnectionManager
+
+
+@pytest.mark.parametrize('add_argument,expected_timeout', [
+    ('', 5),
+    (' --timeout 7', 7),
+    (' --timeout 200', 200),
+    (' --timeout 33.3', 33.3),
+])
+def test_serial_tmcl(add_argument, expected_timeout):
+    """Check if the timeout is forwarded to the serial interface."""
+
+    cm = ConnectionManager("--interface serial_tmcl --port COM4 --data-rate 115200" + add_argument)
+
+    with cm.connect() as myinterface:
+        assert myinterface._serial.timeout == expected_timeout
+
+
+@pytest.mark.parametrize('add_argument,expected_timeout', [
+    ('', 5),
+    (' --timeout 7', 7),
+    (' --timeout 200', 200),
+    (' --timeout 33.3', 33.3),
+])
+def test_kvaser_tmcl(add_argument, expected_timeout):
+    """Check if the timeout is forwarded to the Kvaser interface."""
+
+    cm = ConnectionManager("--interface kvaser_tmcl" + add_argument)
+
+    with cm.connect() as myinterface:
+        assert myinterface._timeout_s == expected_timeout
+
+
+@pytest.mark.parametrize('con_man_call,expected_exception', [
+    ('--interface serial_tmcl --port COM4 --data-rate 115200', RuntimeError),
+    ('--interface kvaser_tmcl', ConnectionError),
+])
+def test_actual_timeout(con_man_call, expected_exception):
+    """We just call the receive-function without sending anything and check if a timeout will be raised."""
+
+    cm = ConnectionManager(f"{con_man_call} --timeout 1.5")
+
+    with pytest.raises(expected_exception) as exec_info:
+        with cm.connect() as myinterface:
+            start_time = time.perf_counter()
+            myinterface._recv(0, 0)
+    stop_time = time.perf_counter()
+    duration = stop_time - start_time
+    assert 1.5 < duration < 1.7
+
+
+@pytest.mark.parametrize('timeout_argument', [
+    'string',
+    '0',
+    '0x1F'
+])
+def test_invalid_timeout(timeout_argument):
+    """Test some invalid arguments for the timeout value."""
+    with pytest.raises(SystemExit) as exec_info:
+        ConnectionManager(f"--interface serial_tmcl --port COM4 --data-rate 115200 --timeout {timeout_argument}")


### PR DESCRIPTION
As a first step this adds the timeout at connection time, the runtime changeable time out will come soon.

Before merging dev into master I will also get rid of the debug argument, for print-like logging.