### PR TITLE
Update stallguard2_module.py to retrieve StallGuard2 threshold signed

### DIFF
--- a/pytrinamic/features/stallguard2_module.py
+++ b/pytrinamic/features/stallguard2_module.py
@@ -53,7 +53,7 @@ class StallGuard2Module(StallGuard2):
 
         Returns: StallGuard2 threshold.
         """
-        return self._parent.get_axis_parameter(self._aps.SG2Threshold, self._axis)
+        return self._parent.get_axis_parameter(self._aps.SG2Threshold, self._axis, signed=True)
 
     def set_stop_velocity(self, velocity):
         """


### PR DESCRIPTION
#73 retrieve StallGuard2 threshold signed because it can be negative.