### PR TITLE
Add VIN to IO enum of TMCM6110

### DIFF
--- a/pytrinamic/modules/TMCM6110.py
+++ b/pytrinamic/modules/TMCM6110.py
@@ -190,3 +190,4 @@ class TMCM6110(TMCLModule):
         IN5    = 5
         IN6    = 6
         IN7    = 7
+        VIN    = 8


### PR DESCRIPTION
I noticed, that it is possible to read the voltage as via `get_analog_input`.

This PR assigns an enum member `VIN` to that voltage pin.