### PR TITLE
Improve typing so that TMCM3110 example types smoothly

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,20 @@
+name: reviewdog
+on: [pull_request]
+jobs:
+  mypy:
+    name: runner / mypy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tsuyoshicho/action-mypy@v5
+        with:
+          github_token: ${{ secrets.github_token }}
+          # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
+          reporter: github-pr-review
+          # Change reporter level if you need.
+          # GitHub Status Check won't become failure with warning.
+          level: warning
+          # Change the current directory to run mypy command.
+          # mypy command reads setup.cfg or other settings file in this path.
+          workdir: pytrinamic
+          mypy_flags: --disable-error-code=import-untyped

--- a/examples/modules/TMCM3110/TMCL/rotate_demo.py
+++ b/examples/modules/TMCM3110/TMCL/rotate_demo.py
@@ -41,12 +41,12 @@ with connection_manager.connect() as my_interface:
     print(motor_2.drive_settings)
 
     # preparing linear ramp settings
-    motor_0.max_acceleration = 1000
-    motor_0.max_velocity = 1000
-    motor_1.max_acceleration = 1000
-    motor_1.max_velocity = 1000
-    motor_2.max_acceleration = 1000
-    motor_2.max_velocity = 1000
+    motor_0.linear_ramp.max_acceleration = 1000
+    motor_0.linear_ramp.max_velocity = 1000
+    motor_1.linear_ramp.max_acceleration = 1000
+    motor_1.linear_ramp.max_velocity = 1000
+    motor_2.linear_ramp.max_acceleration = 1000
+    motor_2.linear_ramp.max_velocity = 1000
 
     # reset actual position
     motor_0.actual_position = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,9 @@ find = {}
 
 [tool.setuptools.dynamic]
 version = { attr = "pytrinamic.version.__version__" }
+
+[tool.ruff.lint.isort]
+force-single-line = true
+
+[tool.isort]
+force_single_line = true

--- a/pytrinamic/connections/can_tmcl_interface.py
+++ b/pytrinamic/connections/can_tmcl_interface.py
@@ -27,20 +27,11 @@ class CanTmclInterface(TmclInterface):
 
         self.logger = logging.getLogger(f"{self.__class__.__name__}.{self._channel}")
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exit_type, value, traceback):
-        """
-        Close the connection at the end of a with-statement block.
-        """
-        del exit_type, value, traceback
-        self.close()
-
     def close(self):
         self.logger.info("Shutdown.")
 
-        self._connection.shutdown()
+        if self._connection is not None:
+            self._connection.shutdown()
 
     def _send(self, host_id, module_id, data):
         """

--- a/pytrinamic/connections/connection_manager.py
+++ b/pytrinamic/connections/connection_manager.py
@@ -6,21 +6,23 @@
 # This software is proprietary to Analog Devices, Inc. and its licensors.
 ################################################################################
 
-import sys
-import logging
 import argparse
+import logging
+import sys
 from dataclasses import dataclass
+from typing import Type
 
 from ..connections import DummyTmclInterface
-from ..connections import PcanTmclInterface
-from ..connections import SocketcanTmclInterface
+from ..connections import IxxatTmclInterface
 from ..connections import KvaserTmclInterface
+from ..connections import PcanTmclInterface
 from ..connections import SerialTmclInterface
+from ..connections import SlcanTmclInterface
+from ..connections import SocketcanTmclInterface
+from ..connections import SocketTmclInterface
 from ..connections import UartIcInterface
 from ..connections import UsbTmclInterface
-from ..connections import SlcanTmclInterface
-from ..connections import IxxatTmclInterface
-from ..connections import SocketTmclInterface
+from .tmcl_interface import TmclInterface
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +103,7 @@ class ConnectionManager:
     @dataclass
     class _Interface:
         name: str
-        class_type: None
+        class_type: Type[TmclInterface]
         default_datarate: int
 
     # All available interfaces
@@ -113,6 +115,7 @@ class ConnectionManager:
         _Interface("slcan_tmcl", SlcanTmclInterface, 1000000),
         _Interface("socketcan_tmcl", SocketcanTmclInterface, 1000000),
         _Interface("serial_tmcl", SerialTmclInterface, 9600),
+        # FIXME: UartIcInterface is not a subclass of TmclInterface
         _Interface("uart_ic", UartIcInterface, 9600),
         _Interface("usb_tmcl", UsbTmclInterface, 115200),
         _Interface("ixxat_tmcl", IxxatTmclInterface, 1000000),
@@ -217,7 +220,7 @@ class ConnectionManager:
             self.__module_id,
         )
 
-    def connect(self):
+    def connect(self) -> TmclInterface:
         """
         Attempt to connect to a module with the stored connection parameters.
 

--- a/pytrinamic/connections/dummy_tmcl_interface.py
+++ b/pytrinamic/connections/dummy_tmcl_interface.py
@@ -26,22 +26,6 @@ class DummyTmclInterface(TmclInterface):
 
         self.logger.debug("Opening port (baudrate=%s).", datarate)
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exit_type, value, traceback):
-        """
-        Close the connection at the end of a with-statement block.
-        """
-        del exit_type, value, traceback
-        self.close()
-
-    def close(self):
-        """
-        Closes the dummy TMCL connection
-        """
-
-
     def _send(self, host_id, module_id, data):
         """
             Send the bytearray parameter [data].

--- a/pytrinamic/connections/serial_tmcl_interface.py
+++ b/pytrinamic/connections/serial_tmcl_interface.py
@@ -35,16 +35,6 @@ class SerialTmclInterface(TmclInterface):
         except SerialException as e:
             raise ConnectionError from e
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exit_type, value, traceback):
-        """
-        Close the connection at the end of a with-statement block.
-        """
-        del exit_type, value, traceback
-        self.close()
-
     def close(self):
         self.logger.info("Closing port.")
         self._serial.close()

--- a/pytrinamic/connections/socket_tmcl_interface.py
+++ b/pytrinamic/connections/socket_tmcl_interface.py
@@ -73,19 +73,10 @@ class SocketTmclInterface(TmclInterface):
                     "Failed to (re-)connect to Socket connection"
                 ) from e
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exitType, value, traceback):
-        """
-        Close the connection at the end of a with-statement block.
-        """
-        del exitType, value, traceback
-        self.close()
-
     def close(self):
         self.logger.info("Closing Socket connection.")
-        self._socket.close()
+        if self._socket is not None:
+            self._socket.close()
 
     def _send(self, host_id, module_id, data):
         """

--- a/pytrinamic/connections/tmcl_interface.py
+++ b/pytrinamic/connections/tmcl_interface.py
@@ -59,6 +59,19 @@ class TmclInterface(ABC):
         self._default_ap_index_bit_width = default_ap_index_bit_width
         self._default_register_address_bit_width = default_register_address_bit_width
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exit_type, value, traceback):
+        """
+        Close the connection at the end of a with-statement block.
+        """
+        del exit_type, value, traceback
+        self.close()
+
+    def close(self):
+        pass
+
     def _send(self, host_id, module_id, data):
         """
         Send the bytearray [data] representing a TMCL command. The length of

--- a/pytrinamic/datalogger.py
+++ b/pytrinamic/datalogger.py
@@ -13,16 +13,24 @@ Improvements/Todo:
 """
 
 from __future__ import annotations
-from typing import Union, List, Dict, Tuple
-from dataclasses import dataclass
-from enum import Enum, auto
-import warnings
-import math
 
-from pytrinamic.rd import Rd
-from pytrinamic.modules.tmcl_module import ParameterGroup, Parameter
-from pytrinamic.ic.tmc_ic import Register, Field
+import math
+import warnings
+from dataclasses import dataclass
+from enum import Enum
+from enum import auto
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
+
 from pytrinamic.helpers import to_signed_32
+from pytrinamic.ic.tmc_ic import Field
+from pytrinamic.ic.tmc_ic import Register
+from pytrinamic.modules.tmcl_module import Parameter
+from pytrinamic.modules.tmcl_module import ParameterGroup
+from pytrinamic.rd import Rd
 
 
 class DataLoggerConfigError(Exception):
@@ -186,10 +194,10 @@ class DataLogger:
             pretrigger_samples_per_channel: int = 0
         samples_per_channel: int
         log_data: dict
-        down_sampling_factor: int = None
-        sample_rate_hz: float = None
+        down_sampling_factor: Optional[int] = None
+        sample_rate_hz: Optional[float] = None
         allow_sample_rate_round_down: bool = False
-        trigger: Trigger = None
+        trigger: Optional[Trigger] = None
 
         def set_sample_rate(self, rate_hz: float, *, round_down=False) -> float:
             """

--- a/pytrinamic/modules/TMCM3110.py
+++ b/pytrinamic/modules/TMCM3110.py
@@ -6,18 +6,20 @@
 # This software is proprietary to Analog Devices, Inc. and its licensors.
 ################################################################################
 
+from ..connections.tmcl_interface import TmclInterface
+from ..features import CoolStepModule
+from ..features import DriveSettingModule
+from ..features import LinearRampModule
+from ..features import MotorControlModule
+from ..features import StallGuard2Module
 from ..modules import TMCLModule
-
-# features
-from ..features import MotorControlModule, DriveSettingModule, LinearRampModule
-from ..features import StallGuard2Module, CoolStepModule
 
 
 class TMCM3110(TMCLModule):
     """
     The TMCM-3110 is a three axis stepper motor controller/driver module for sensorless load dependent current control.
     """
-    def __init__(self, connection, module_id=1):
+    def __init__(self, connection: TmclInterface, module_id=1):
         super().__init__(connection, module_id)
         self.name = "TMCM-3110"
         self.desc = self.__doc__

--- a/pytrinamic/modules/tmcl_module.py
+++ b/pytrinamic/modules/tmcl_module.py
@@ -9,13 +9,15 @@
 import enum
 import inspect
 import warnings
+from typing import Optional
+from typing import Union
 
-from typing import Optional, Union
+from ..connections.tmcl_interface import TmclInterface
 
 
 class TMCLModule(object):
 
-    def __init__(self, connection, module_id=1, ap_index_bit_width=8):
+    def __init__(self, connection: TmclInterface, module_id=1, ap_index_bit_width=8):
         """
         Constructor for the module instance.
 
@@ -242,7 +244,7 @@ class Parameter:
 
 class ParameterApiDevice:
 
-    def get_parameter(self, get_target: Union[Parameter]):
+    def get_parameter(self, get_target: Parameter):
         """Get the value of a parameter using the GAP or GGP command."""
         if isinstance(get_target, Parameter):
             parameter = get_target


### PR DESCRIPTION
- ~~Hoist `__enter__`/`__exit__` from subclasses into `TmclInterface`~~ (#128)
- Add a few `if X is not None`
- Add config for consistent import sorting. (Imports are now always single-line, as this seemed to be the consensus.)
- ~~Add job to detect if a pull request introduces typing problems~~ (#129)

Related to #125.